### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ API docs should look like:
 
 It is helpful to standardize some markdown conventions so readers learn to recognize visual cues as they work their way through the documentation and tutorials. Following are the conventions used for the Spree documentation:
 
-####Class Names####
+#### Class Names ####
 
 When referencing the name of a class, it should be capitalized. If you are writing explanatory prose and not a section of code, the class name should be blocked out with tick (`) marks. For example:
 
@@ -91,7 +91,7 @@ An instance of a class should be lowercase, normal font:
 
     You can view all of the orders for a particular user.
 
-####Buttons, Links, Section Names, Form Elements####
+#### Buttons, Links, Section Names, Form Elements ####
 
 These should always reference the correct label and can have their names quoted. Examples:
 
@@ -100,24 +100,24 @@ These should always reference the correct label and can have their names quoted.
 * Information displayed in the "Purchase Funnel" section gives you information...
 * If you check "Receive Stock" while creating a new transfer...
 
-####States, Attributes, Methods, Events, and Parameters####
+#### States, Attributes, Methods, Events, and Parameters ####
 When referring to the state of an object - an order, for example - the state name should be lowercase and set off with tick (`) marks. For example:
 
     Orders that are in the `address` state do not have valid shipping and billing addresses assigned to them yet.
 
 This same style is used for attribute names and their settings, method names, event names, parameter names, parameter settings, and data types.
 
-####Path Names####
+#### Path Names ####
 Path names should be set off with tick (`) marks, and should include enough of the directory structure to make it clear which file is being referenced. For example:
 
     They are defined in `core/app/models/spree/app_configuration.rb`...
 
-####Adding Emphasis####
+#### Adding Emphasis ####
 Any text that needs to be emphasized should be in _italics_.
 
     Only the shipping options in the _shipping_ address are presented.
 
-####Terminal Blocks####
+#### Terminal Blocks ####
 
 You can specify terminal blocks by setting it off with \`\`\`bash.
 In addition, you can differentiate commands you are using from output
@@ -130,7 +130,7 @@ $ c
 => "Hello world"
 ```
 
-####Special Blocks####
+#### Special Blocks ####
 
 Certain blocks of text can be wrapped in sets of three characters, which will place them in divs with appropriate CSS classes. They are:
 

--- a/content/developer/source/contributing.md
+++ b/content/developer/source/contributing.md
@@ -241,7 +241,7 @@ $ nanoc view
 
 It is helpful to standardize some markdown conventions so readers learn to recognize visual cues as they work their way through the documentation and tutorials. Following are the conventions used for the Spree documentation:
 
-####Class Names####
+#### Class Names ####
 
 When referencing the name of a class, it should be capitalized. If you are writing explanatory prose and not a section of code, the class name should be blocked out with tick (`) marks. For example:
 
@@ -253,7 +253,7 @@ An instance of a class should be lowercase, normal font:
 
     You can view all of the orders for a particular user.
 
-####Buttons, Links, Section Names, Form Elements####
+#### Buttons, Links, Section Names, Form Elements ####
 
 These should always reference the correct label and can have their names quoted. Examples:
 
@@ -262,24 +262,24 @@ These should always reference the correct label and can have their names quoted.
 * Information displayed in the "Purchase Funnel" section gives you information...
 * If you check "Receive Stock" while creating a new transfer...
 
-####States, Attributes, Methods, Events, and Parameters####
+#### States, Attributes, Methods, Events, and Parameters ####
 When referring to the state of an object - an order, for example - the state name should be lowercase and set off with tick (`) marks. For example:
 
     Orders that are in the `address` state do not have valid shipping and billing addresses assigned to them yet.
 
 This same style is used for attribute names and their settings, method names, event names, parameter names, parameter settings, and data types.
 
-####Path Names####
+#### Path Names ####
 Path names should be set off with tick (`) marks, and should include enough of the directory structure to make it clear which file is being referenced. For example:
 
     They are defined in `core/app/models/spree/app_configuration.rb`...
 
-####Adding Emphasis####
+#### Adding Emphasis ####
 Any text that needs to be emphasized should be in _italics_.
 
     Only the shipping options in the _shipping_ address are presented.
 
-####Terminal Blocks####
+#### Terminal Blocks ####
 You can specify terminal blocks by setting it off with <code>```bash</code>. In addition, you can differentiate commands you are using from output returned by using the `$` precursor for input and `=>` precursor for output.
 
 ```bash
@@ -289,7 +289,7 @@ $ c
 => "Hello world"
 ```
 
-####Special Blocks####
+#### Special Blocks ####
 
 Certain blocks of text can be wrapped in sets of three characters, which will place them in divs with appropriate CSS classes. They are:
 

--- a/content/developer/tutorials/migration.markdown
+++ b/content/developer/tutorials/migration.markdown
@@ -469,10 +469,10 @@ polymorphic. Given some local image file, the following will associate the image
 create all of the size formats.
 
 ```ruby
-#for image for product (all variants) represented by master variant
+# for image for product (all variants) represented by master variant
 img = Spree::Image.create(:attachment => File.open(path), :viewable => product.master)
 
-#for image for single variant
+# for image for single variant
 img = Spree::Image.create(:attachment => File.open(path), :viewable => variant)
 ```
 

--- a/content/release_notes/1_1_4.md
+++ b/content/release_notes/1_1_4.md
@@ -67,7 +67,7 @@ this:
 ```
 
 These changes are important, as they fix [Issue
-#1854](https://github.com/spree/spree/issues/1854).
+# 1854](https://github.com/spree/spree/issues/1854).
 
 # Minor fixes
 

--- a/content/release_notes/1_2_0.md
+++ b/content/release_notes/1_2_0.md
@@ -23,7 +23,7 @@ has been removed completely and placed into a separate extension called
 [spree_auth_devise](https://github.com/spree/spree_auth_devise). If
 you wish to continue using this component of Spree, you will need to
 specify this extension as a dependency in your Gemfile. See [Issue
-#1512](https://github.com/spree/spree/pull/1512) for more detail about
+# 1512](https://github.com/spree/spree/pull/1512) for more detail about
 the customization.
 
 The checkout process has always been hard to customize within Spree, and
@@ -31,8 +31,8 @@ that has generated complaints in the past. We are pleased to report in
 the 1.2 release of Spree that this has been substaintially easier with a
 new checkout DSL that allows you to re-define the checkout steps in a
 simple manner. For more information about this, please see [Issue
-#1418](https://github.com/spree/spree/pull/1418) and [Issue
-#1743](https://github.com/spree/spree/pull/1743).
+# 1418](https://github.com/spree/spree/pull/1418) and [Issue
+# 1743](https://github.com/spree/spree/pull/1743).
 
 Along with these two major issues, there were also a ton of minor
 improvements and bug fixes, explained in detail below.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
