### PR TITLE
Remove deprecated custom template documentation

### DIFF
--- a/content/api/summary.md
+++ b/content/api/summary.md
@@ -65,8 +65,8 @@ The following are some simple rules that all Spree API endpoints comply with.
 
 ## Customizing Responses
 
-If you wish to customize the responses from the API, you can do this in one of
-two ways: overriding the template, or providing a custom template.
+If you wish to customize the responses from the API, you can only do this
+in one way: overriding the template
 
 ### Overriding template
 
@@ -83,33 +83,3 @@ For instance, if you place a template in your application at
 template within the API engine.
 
 This is the method we would recommend to *completely* override an API response.
-
-### Custom template
-
-If you don't want to always override the response for an API controller, you can
-customize it in another way by creating an alternative template to use for some
-API responses.
-
-To do this, create a template under the view directory of your targetted
-resource. For instance, if you wanted to customize a response for one of the
-actions within the `ProductsController` of the API, you would place the template
-at `app/views/spree/api/products`. The template must be given a unique name that
-won't conflict with any other templates; you could call it `small_show` for
-instance.
-
-If you were to take this route, the new template file's path would be
-`app/views/spree/api/products/small_show.v1.rabl`. The `v1` part of the filename
-indicates that its a response for version 1 of the API, and the `rabl` on the
-end is the markup language used.
-
-To use this new template for your API response, simply pass the `template`
-parameter along with the request:
-`http://example.com/api/products/1?template=small_show`. The API component of
-Spree will then detect this parameter, find the template, and then use this to
-render the response.
-
-***
-Due to [the way this implemented](https://github.com/spree/spree/blob/v2.3.1/api/lib/spree/api/responders/rabl_template.rb#L5-L18)
-you need to ensure the action rendering in your custom template explicitly
-calls `respond_with`
-***


### PR DESCRIPTION
Remove deprecated custom template documentation. There's no way to specify a custom template.